### PR TITLE
Add log-path option to show and copy log directory path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "platformdirs>=4.1.0",
-    "click>=8.1.7"
+    "platformdirs~=4.2.0",
+    "click~=8.1.7",
+    "pyperclip~=1.8.2"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-platformdirs>=4.1.0
-click>=8.1.7
+platformdirs~=4.2.0
+click~=8.1.7
+pyperclip~=1.8.2

--- a/src/ypkgupgr/__init__.py
+++ b/src/ypkgupgr/__init__.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 
 import click
+import pyperclip
 
 from .appdata import create_appdata_dirs, log_dir
 from .colors import Colors
@@ -265,8 +266,20 @@ def unignore_all(clear_log, log_debug_var):
 
 
 @update_command.command(help="Open the logs directory with your default file explorer and exit.")
-def open_logs():
+@click.option('--clear-log', is_flag=True, help='Clear the log file before writing to it.')
+@click.option('--log-debug', 'log_debug_var', is_flag=True, help='Log debug information.')
+def open_logs(clear_log, log_debug_var):
     click.launch(log_dir)
+
+
+@update_command.command(help="Show and copy the path to the logs directory and exit.")
+@click.option('--clear-log', is_flag=True, help='Clear the log file before writing to it.')
+@click.option('--log-debug', 'log_debug_var', is_flag=True, help='Log debug information.')
+def log_path(clear_log, log_debug_var):
+    print("Log path:")
+    print(log_dir)
+    pyperclip.copy(log_dir)
+    print("Path copied to clipboard.")
 
 
 def run_from_script():

--- a/src/ypkgupgr/__init__.py
+++ b/src/ypkgupgr/__init__.py
@@ -276,10 +276,13 @@ def open_logs(clear_log, log_debug_var):
 @click.option('--clear-log', is_flag=True, help='Clear the log file before writing to it.')
 @click.option('--log-debug', 'log_debug_var', is_flag=True, help='Log debug information.')
 def log_path(clear_log, log_debug_var):
+    init_logging(clear_log, log_debug_var)
     print("Log path:")
     print(log_dir)
     pyperclip.copy(log_dir)
     print("Path copied to clipboard.")
+
+    log_debug(f"Copied path to clipboard: {log_dir}")
 
 
 def run_from_script():


### PR DESCRIPTION
Usage: `ypkgupgr log-path`
Example result:
```
Log path:
C:\Users\user\AppData\Local\Yesser Studios\ypkgupgr\Logs
Path copied to clipboard.
```

Closes #51.