### PR TITLE
Exit alternate buffer when no packages are outdated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "platformdirs~=4.3.0",
-    "click~=8.1.7",
+    "click~=8.2.0",
     "pyperclip~=1.9.0"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 platformdirs~=4.3.0
-click~=8.1.7
+click~=8.2.0
 pyperclip>=1.9.0

--- a/src/ypkgupgr/__init__.py
+++ b/src/ypkgupgr/__init__.py
@@ -155,6 +155,11 @@ def update_packages(non_interactive: bool = False):
         progress_ring(progress=100, complete=True)
         print("No outdated packages found.")
         logger.info("No outdated packages.")
+
+        if not non_interactive:
+            input("Press Enter to exit.")
+        exit_alternate_buffer()
+
         return
 
     outdated_count = len(lines)


### PR DESCRIPTION
- **Bump click to 8.2.x**
- **Exit alternate buffer when no packages are outdated**

Fixes #70.
